### PR TITLE
Add intrinsic content size to PathView

### DIFF
--- a/Scalar2D.xcodeproj/project.pbxproj
+++ b/Scalar2D.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		21FFE8E51D646669003446DF /* PathView+Cross.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFE8E41D646669003446DF /* PathView+Cross.swift */; };
 		21FFE8E61D646669003446DF /* PathView+Cross.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FFE8E41D646669003446DF /* PathView+Cross.swift */; };
 		21FFE8EA1D6473D3003446DF /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21FFE8E91D6473D3003446DF /* CoreGraphics.framework */; };
+		36CFD08720595A02007355EF /* PathView+iOS.swift in Headers */ = {isa = PBXBuildFile; fileRef = 21E326C81D5B411900B64C7C /* PathView+iOS.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -488,6 +489,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				21FFE8C91D63009D003446DF /* Scalar2D.h in Headers */,
+				36CFD08720595A02007355EF /* PathView+iOS.swift in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Views/UIKit/Source/PathView+iOS.swift
+++ b/Views/UIKit/Source/PathView+iOS.swift
@@ -75,6 +75,9 @@ extension UIViewContentMode
         didSet
         {
             self.shapeLayer.lineWidth = lineWidth
+            self.invalidateIntrinsicContentSize()
+            setNeedsLayout()
+            setNeedsDisplay()
         }
     }
     
@@ -83,6 +86,7 @@ extension UIViewContentMode
         didSet
         {
             self.shapeLayer.fillColor = fillColor?.cgColor
+            setNeedsDisplay()
         }
     }
     
@@ -91,6 +95,7 @@ extension UIViewContentMode
         didSet
         {
             self.shapeLayer.strokeColor = strokeColor?.cgColor
+            setNeedsDisplay()
         }
     }
     
@@ -99,6 +104,9 @@ extension UIViewContentMode
         didSet
         {
             self.setPathString(pathString: svgPath)
+            self.invalidateIntrinsicContentSize()
+            setNeedsLayout()
+            setNeedsDisplay()
         }
     }
     
@@ -120,4 +128,9 @@ extension UIViewContentMode
         return CAShapeLayer.self
     }
 
+    public override var intrinsicContentSize: CGSize {
+        let pathSize = shapeLayer.path?.boundingBoxOfPath.size ?? .zero
+        let sizeWithLineWidth = CGRect(origin: .zero, size: pathSize).insetBy(dx: 2 * lineWidth, dy: 2 * lineWidth).size
+        return sizeWithLineWidth
+    }
 }


### PR DESCRIPTION
Hi, 

This is working nicely when run in the simulator/device, but does not work as well (as UILabel for instance) with Interface Builder. I can't seem to figure out how to get sizeToFit to work from IB.