### PR TITLE
Permit dot at the beginning of a continuation parameter

### DIFF
--- a/GraphicPath/Source/PathGenerator.swift
+++ b/GraphicPath/Source/PathGenerator.swift
@@ -235,7 +235,7 @@ public extension String
                             }
                             else
                             {
-                                throw PathToken.FailureReason.unexpectedCharacter(badCharacter: character, offset: index)
+                                self.activeParameterEndIndex = index
                             }
                         }
                         else


### PR DESCRIPTION
Fixes #6